### PR TITLE
feat(session): add session abstraction POC with $_SESSION storage

### DIFF
--- a/src/Session/AbstractedSessionHandler.php
+++ b/src/Session/AbstractedSessionHandler.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webstract\Session;
+
+use Webstract\Session\Exception\SessionProviderUnreachableException;
+use Webstract\Session\Exception\SessionValueNotFoundException;
+
+final class AbstractedSessionHandler implements SessionHandler
+{
+	public function __construct(private SessionStorageInterface $storage)
+	{
+	}
+
+	/**
+	 * @throws SessionProviderUnreachableException
+	 */
+	public function initSession(): void
+	{
+		$this->storage->initSession();
+	}
+
+	public function destroySession(): void
+	{
+		$this->storage->destroySession();
+	}
+
+	/**
+	 * @throws SessionValueNotFoundException
+	 */
+	public function get(SessionKeyInterface $key): mixed
+	{
+		$keyName = $key->getName();
+		if (!$this->storage->has($keyName)) {
+			throw new SessionValueNotFoundException(sprintf('Session value `%s` was not found', $keyName));
+		}
+
+		return $this->storage->get($keyName);
+	}
+
+	public function getOrDefault(SessionKeyInterface $key, mixed $default = null): mixed
+	{
+		if (!$this->storage->has($key->getName())) {
+			return $default;
+		}
+
+		return $this->storage->get($key->getName());
+	}
+
+	public function set(SessionKeyInterface $key, mixed $value): void
+	{
+		$this->storage->set($key->getName(), $value);
+	}
+
+	public function has(SessionKeyInterface $key): bool
+	{
+		return $this->storage->has($key->getName());
+	}
+
+	public function delete(SessionKeyInterface $key): void
+	{
+		$this->storage->delete($key->getName());
+	}
+
+	/**
+	 * @throws SessionValueNotFoundException
+	 */
+	public function consume(SessionKeyInterface $key): mixed
+	{
+		$value = $this->get($key);
+		$this->delete($key);
+
+		return $value;
+	}
+
+	public function consumeOrDefault(SessionKeyInterface $key, mixed $default = null): mixed
+	{
+		$value = $this->getOrDefault($key, $default);
+		$this->delete($key);
+
+		return $value;
+	}
+}

--- a/src/Session/SessionStorageInterface.php
+++ b/src/Session/SessionStorageInterface.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webstract\Session;
+
+interface SessionStorageInterface
+{
+	/**
+	 * @return void
+	 */
+	public function initSession(): void;
+
+	/**
+	 * @return void
+	 */
+	public function destroySession(): void;
+
+	/**
+	 * @param string $key
+	 * @return bool
+	 */
+	public function has(string $key): bool;
+
+	/**
+	 * @param string $key
+	 * @return mixed
+	 */
+	public function get(string $key): mixed;
+
+	/**
+	 * @param string $key
+	 * @param mixed $value
+	 * @return void
+	 */
+	public function set(string $key, mixed $value): void;
+
+	/**
+	 * @param string $key
+	 * @return void
+	 */
+	public function delete(string $key): void;
+}

--- a/src/Session/SuperglobalSessionStorage.php
+++ b/src/Session/SuperglobalSessionStorage.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webstract\Session;
+
+use Webstract\Session\Exception\SessionProviderUnreachableException;
+
+final class SuperglobalSessionStorage implements SessionStorageInterface
+{
+	/**
+	 * @throws SessionProviderUnreachableException
+	 */
+	public function initSession(): void
+	{
+		if (session_status() === \PHP_SESSION_ACTIVE) {
+			return;
+		}
+
+		if (!session_start()) {
+			throw new SessionProviderUnreachableException('Unable to start session provider');
+		}
+	}
+
+	public function destroySession(): void
+	{
+		if (session_status() !== \PHP_SESSION_ACTIVE) {
+			$_SESSION = [];
+			return;
+		}
+
+		$_SESSION = [];
+		session_destroy();
+	}
+
+	public function has(string $key): bool
+	{
+		return array_key_exists($key, $_SESSION);
+	}
+
+	public function get(string $key): mixed
+	{
+		return $_SESSION[$key];
+	}
+
+	public function set(string $key, mixed $value): void
+	{
+		$_SESSION[$key] = $value;
+	}
+
+	public function delete(string $key): void
+	{
+		unset($_SESSION[$key]);
+	}
+}

--- a/test-support/Session/FakeSessionKey.php
+++ b/test-support/Session/FakeSessionKey.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Support\Session;
+
+use Webstract\Session\SessionKeyInterface;
+
+final class FakeSessionKey implements SessionKeyInterface
+{
+	public function __construct(private string $name)
+	{
+	}
+
+	public function getName(): string
+	{
+		return $this->name;
+	}
+}

--- a/test/Session/AbstractedSessionHandlerTest.php
+++ b/test/Session/AbstractedSessionHandlerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Session;
+
+use Test\Support\Session\FakeSessionKey;
+use Test\TestCase;
+use Webstract\Session\AbstractedSessionHandler;
+use Webstract\Session\Exception\SessionValueNotFoundException;
+use Webstract\Session\SuperglobalSessionStorage;
+
+class AbstractedSessionHandlerTest extends TestCase
+{
+	private AbstractedSessionHandler $handler;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->handler = new AbstractedSessionHandler(new SuperglobalSessionStorage());
+		$_SESSION = [];
+	}
+
+	public function test_SetAndGet_ShouldReadValueFromSession(): void
+	{
+		$key = new FakeSessionKey('foo');
+
+		$this->handler->set($key, 'bar');
+
+		$this->assertSame('bar', $this->handler->get($key));
+	}
+
+	public function test_Get_ShouldThrowException_WhenValueDoesNotExist(): void
+	{
+		$this->expectException(SessionValueNotFoundException::class);
+		$this->expectExceptionMessage('Session value `foo` was not found');
+
+		$this->handler->get(new FakeSessionKey('foo'));
+	}
+
+	public function test_Consume_ShouldReturnValueAndDeleteIt(): void
+	{
+		$key = new FakeSessionKey('foo');
+		$this->handler->set($key, 'bar');
+
+		$this->assertSame('bar', $this->handler->consume($key));
+		$this->assertFalse($this->handler->has($key));
+	}
+
+	public function test_ConsumeOrDefault_ShouldReturnDefault_WhenValueDoesNotExist(): void
+	{
+		$key = new FakeSessionKey('foo');
+
+		$this->assertSame('fallback', $this->handler->consumeOrDefault($key, 'fallback'));
+		$this->assertFalse($this->handler->has($key));
+	}
+
+	protected function tearDown(): void
+	{
+		$_SESSION = [];
+		parent::tearDown();
+	}
+}

--- a/test/Session/SuperglobalSessionStorageTest.php
+++ b/test/Session/SuperglobalSessionStorageTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Session;
+
+use Test\TestCase;
+use Webstract\Session\SuperglobalSessionStorage;
+
+class SuperglobalSessionStorageTest extends TestCase
+{
+	private SuperglobalSessionStorage $storage;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->storage = new SuperglobalSessionStorage();
+		$_SESSION = [];
+	}
+
+	public function test_SetGetHasAndDelete_ShouldOperateOnSuperglobalSession(): void
+	{
+		$this->storage->set('foo', 'bar');
+
+		$this->assertTrue($this->storage->has('foo'));
+		$this->assertSame('bar', $this->storage->get('foo'));
+
+		$this->storage->delete('foo');
+		$this->assertFalse($this->storage->has('foo'));
+	}
+
+	public function test_DestroySession_ShouldClearSessionValues(): void
+	{
+		$this->storage->set('foo', 'bar');
+
+		$this->storage->destroySession();
+
+		$this->assertSame([], $_SESSION);
+	}
+
+	protected function tearDown(): void
+	{
+		$_SESSION = [];
+		parent::tearDown();
+	}
+}


### PR DESCRIPTION
### Motivation
- Decouple session handling logic from storage details so different backends can be used and tested independently.
- Provide a proof-of-concept `$_SESSION`-backed storage to validate the abstraction and expected session behaviours.
- Add tests and a small helper to exercise the new abstraction and ensure parity with the existing `SessionHandler` semantics.

### Description
- Add `SessionStorageInterface` with `initSession`, `destroySession`, `has`, `get`, `set`, and `delete` methods to represent a generic session storage backend.
- Add `AbstractedSessionHandler` that implements `SessionHandler` and delegates persistence to a `SessionStorageInterface`, preserving `get`, `getOrDefault`, `consume`, and `consumeOrDefault` semantics including `SessionValueNotFoundException` handling.
- Add `SuperglobalSessionStorage` as a proof-of-concept implementation that operates on PHP `$_SESSION` and manages session lifecycle via `initSession`/`destroySession`.
- Add a test helper `Test\Support\Session\FakeSessionKey` and unit tests `test/Session/AbstractedSessionHandlerTest.php` and `test/Session/SuperglobalSessionStorageTest.php` that cover set/get/has/delete/consume behaviours.

### Testing
- Ran PHP syntax checks with `php -l` on new source and test files and they all passed.
- Attempted `composer install` but it failed due to network restrictions (GitHub downloads returned HTTP 403), preventing dependency installation.
- Attempted `composer test` but it failed because `vendor/bin/phpunit` is not available until dependencies are installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4e30cfb448324ae3faf2e816f0cf4)