### PR TITLE
Add Runner tests for bind resolution scenarios

### DIFF
--- a/test/Runner/RunnerTest.php
+++ b/test/Runner/RunnerTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Runner;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Test\TestCase;
+use Webstract\Runner\Bind;
+use Webstract\Runner\Runner;
+
+#[CoversClass(Runner::class)]
+#[CoversClass(Bind::class)]
+class RunnerTest extends TestCase
+{
+	public function test_bind_interface_to_pre_instantiated_object(): void
+	{
+		$runner = (new FakeRunner())->withBinds(
+			new Bind(FakeContract::class, new FakeConcreteWithoutDependencies())
+		);
+
+		$resolved = $runner->resolve(FakeContract::class);
+
+		$this->assertInstanceOf(FakeConcreteWithoutDependencies::class, $resolved);
+	}
+
+	public function test_bind_interface_to_concrete_class_without_dependencies(): void
+	{
+		$runner = (new FakeRunner())->withBinds(
+			new Bind(FakeContract::class, FakeConcreteWithoutDependencies::class)
+		);
+
+		$resolved = $runner->resolve(FakeContract::class);
+
+		$this->assertInstanceOf(FakeConcreteWithoutDependencies::class, $resolved);
+	}
+
+	public function test_bind_interface_to_concrete_class_with_constructor_properties_defined_in_bind(): void
+	{
+		$runner = (new FakeRunner())->withBinds(
+			new Bind('runner-test.value', 'bound-value'),
+			(new Bind(FakeContract::class, FakeConcreteWithDependency::class))
+				->withProperties('runner-test.value')
+		);
+
+		$resolved = $runner->resolve(FakeContract::class);
+
+		$this->assertInstanceOf(FakeConcreteWithDependency::class, $resolved);
+		$this->assertSame('bound-value', $resolved->value);
+	}
+
+	public function test_resolves_expected_type_for_each_bind_scenario(): void
+	{
+		$instance = new FakeConcreteWithoutDependencies();
+
+		$runner = (new FakeRunner())->withBinds(
+			new Bind('runner-test.value', 'value-from-bind'),
+			new Bind(FakePreinstantiatedContract::class, $instance),
+			new Bind(FakeNoDependencyContract::class, FakeConcreteWithoutDependencies::class),
+			(new Bind(FakeWithDependencyContract::class, FakeConcreteWithDependency::class))
+				->withProperties('runner-test.value')
+		);
+
+		$preInstantiated = $runner->resolve(FakePreinstantiatedContract::class);
+		$noDependency = $runner->resolve(FakeNoDependencyContract::class);
+		$withDependency = $runner->resolve(FakeWithDependencyContract::class);
+
+		$this->assertSame($instance, $preInstantiated);
+		$this->assertInstanceOf(FakeConcreteWithoutDependencies::class, $noDependency);
+		$this->assertInstanceOf(FakeConcreteWithDependency::class, $withDependency);
+		$this->assertSame('value-from-bind', $withDependency->value);
+	}
+
+	public function test_invalid_bind_throws_exception_on_resolution(): void
+	{
+		$runner = (new FakeRunner())->withBinds(
+			new Bind(FakeContract::class, 'Not\\A\\Valid\\Class')
+		);
+
+		$this->expectException(\Throwable::class);
+		$runner->resolve(FakeContract::class);
+	}
+}
+
+final class FakeRunner extends Runner
+{
+	public function execute(): void
+	{
+	}
+
+	public function resolve(string $id): mixed
+	{
+		return $this->container->get($id);
+	}
+}
+
+interface FakeContract {}
+interface FakePreinstantiatedContract {}
+interface FakeNoDependencyContract {}
+interface FakeWithDependencyContract {}
+
+final class FakeConcreteWithoutDependencies implements FakeContract, FakePreinstantiatedContract, FakeNoDependencyContract
+{
+}
+
+final class FakeConcreteWithDependency implements FakeContract, FakeWithDependencyContract
+{
+	public function __construct(public readonly string $value)
+	{
+	}
+}


### PR DESCRIPTION
### Motivation

- Add unit tests to verify how `Webstract\Runner\Runner` processes `Bind` definitions and how the DI container resolves bound types in several common scenarios.
- Cover both positive cases (object instance, class without dependencies, class with constructor properties) and a negative case for invalid binds to prevent regressions.

### Description

- Add `test/Runner/RunnerTest.php` which defines a `FakeRunner` subclass exposing container resolution for tests. 
- Add fake contracts and concrete classes used to exercise binds (pre-instantiated object, no-dependency class, and class with a constructor dependency).
- Add tests for binding an interface to a pre-instantiated object, to a concrete class without dependencies, and to a concrete class with constructor properties via `Bind::withProperties`.
- Add a combined scenario that verifies all bind types resolve to the expected instances and a negative test that expects an exception for an invalid bind target.

### Testing

- Attempted to run `vendor/bin/phpunit test/Runner/RunnerTest.php --do-not-cache-result --no-progress --colors=never`, but the command failed because `vendor/bin/phpunit` is not available in the environment. 
- No other automated test runs were executed in this environment due to the missing PHPUnit binary.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2a9856598832495e27da1b59fcaf8)