### PR TITLE
test: add contract tests by domain with fake implementers

### DIFF
--- a/test-support/Contracts/Database/FakeDatabaseTransactionManager.php
+++ b/test-support/Contracts/Database/FakeDatabaseTransactionManager.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Support\Contracts\Database;
+
+use RuntimeException;
+use Webstract\Database\DatabaseTransactionManager;
+
+class FakeDatabaseTransactionManager implements DatabaseTransactionManager
+{
+	private bool $inTransaction = false;
+	private bool $shouldFailOnBegin = false;
+	private bool $shouldFailOnCommit = false;
+	private bool $shouldFailOnRollback = false;
+
+	public function failOnBegin(): void { $this->shouldFailOnBegin = true; }
+	public function failOnCommit(): void { $this->shouldFailOnCommit = true; }
+	public function failOnRollback(): void { $this->shouldFailOnRollback = true; }
+
+	public function inTransaction(): bool { return $this->inTransaction; }
+	public function beginTransaction(): bool
+	{
+		if ($this->shouldFailOnBegin) { throw new RuntimeException('begin failed'); }
+		$this->inTransaction = true;
+		return true;
+	}
+	public function commit(): bool
+	{
+		if ($this->shouldFailOnCommit) { throw new RuntimeException('commit failed'); }
+		$this->inTransaction = false;
+		return true;
+	}
+	public function rollBack(): bool
+	{
+		if ($this->shouldFailOnRollback) { throw new RuntimeException('rollback failed'); }
+		$this->inTransaction = false;
+		return true;
+	}
+}

--- a/test-support/Contracts/Database/FakeRepository.php
+++ b/test-support/Contracts/Database/FakeRepository.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Support\Contracts\Database;
+
+use RuntimeException;
+use Webstract\Database\DatabaseRepositoryConnector;
+use Webstract\Database\Repository;
+
+class FakeRepository implements Repository
+{
+	public function __construct(private readonly DatabaseRepositoryConnector $connector)
+	{
+	}
+
+	public function connector(): DatabaseRepositoryConnector
+	{
+		return $this->connector;
+	}
+
+	public function run(callable $operation): mixed
+	{
+		$result = $operation();
+		if ($result instanceof RuntimeException) {
+			throw $result;
+		}
+		return $result;
+	}
+}

--- a/test-support/Contracts/Pdf/FakePdfGenerator.php
+++ b/test-support/Contracts/Pdf/FakePdfGenerator.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Support\Contracts\Pdf;
+
+use RuntimeException;
+use Webstract\Pdf\PdfContent;
+use Webstract\Pdf\PdfGenerator;
+use Webstract\TemplateEngine\TemplateEngineRenderer;
+
+class FakePdfGenerator implements PdfGenerator
+{
+	public bool $shouldThrow = false;
+
+	public function __construct(private readonly TemplateEngineRenderer $templateEngine)
+	{
+	}
+
+	public function generateContent(PdfContent $pdfContent): string
+	{
+		if ($this->shouldThrow) {
+			throw new RuntimeException('pdf generation failed');
+		}
+
+		return 'PDF:' . $this->templateEngine->render($pdfContent->getHtmlPath(), $pdfContent->getContext());
+	}
+}

--- a/test-support/Contracts/Session/FakeSessionHandlers.php
+++ b/test-support/Contracts/Session/FakeSessionHandlers.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Support\Contracts\Session;
+
+use Webstract\Session\Exception\SessionMissingException;
+use Webstract\Session\Exception\SessionProviderUnreachableException;
+use Webstract\Session\Exception\SessionValueNotFoundException;
+use Webstract\Session\KeyValueSessionHandler;
+use Webstract\Session\SessionHandler;
+use Webstract\Session\SessionKeyInterface;
+
+class FakeSessionHandler implements SessionHandler
+{
+	private array $values = [];
+	public bool $initialized = false;
+	public function initSession(): void { $this->initialized = true; }
+	public function destroySession(): void { $this->values = []; $this->initialized = false; }
+	public function get(SessionKeyInterface $key): mixed
+	{
+		if (!$this->has($key)) throw new SessionValueNotFoundException();
+		return $this->values[$key->getName()];
+	}
+	public function getOrDefault(SessionKeyInterface $key, mixed $default = null): mixed { return $this->values[$key->getName()] ?? $default; }
+	public function set(SessionKeyInterface $key, mixed $value): void { $this->values[$key->getName()] = $value; }
+	public function has(SessionKeyInterface $key): bool { return array_key_exists($key->getName(), $this->values); }
+	public function delete(SessionKeyInterface $key): void { unset($this->values[$key->getName()]); }
+	public function consume(SessionKeyInterface $key): mixed { $value = $this->get($key); $this->delete($key); return $value; }
+	public function consumeOrDefault(SessionKeyInterface $key, mixed $default = null): mixed { $value = $this->getOrDefault($key, $default); $this->delete($key); return $value; }
+}
+
+class FakeKeyValueSessionHandler implements KeyValueSessionHandler
+{
+	private array $sessions = [];
+	public function initSession(): string { $id = 'sess-' . (count($this->sessions) + 1); $this->sessions[$id] = []; return $id; }
+	public function destroySession(string $sessId): void { $this->assertSessionExists($sessId); unset($this->sessions[$sessId]); }
+	public function get(string $sessId, SessionKeyInterface $key): mixed
+	{ $this->assertSessionExists($sessId); if (!$this->has($sessId, $key)) throw new SessionValueNotFoundException(); return $this->sessions[$sessId][$key->getName()]; }
+	public function getOrDefault(string $sessId, SessionKeyInterface $key, mixed $default = null): mixed
+	{ $this->assertSessionExists($sessId); return $this->sessions[$sessId][$key->getName()] ?? $default; }
+	public function set(string $sessId, SessionKeyInterface $key, mixed $value): void { $this->assertSessionExists($sessId); $this->sessions[$sessId][$key->getName()] = $value; }
+	public function has(string $sessId, SessionKeyInterface $key): bool { $this->assertSessionExists($sessId); return array_key_exists($key->getName(), $this->sessions[$sessId]); }
+	public function delete(string $sessId, SessionKeyInterface $key): void { $this->assertSessionExists($sessId); unset($this->sessions[$sessId][$key->getName()]); }
+	public function consume(string $sessId, SessionKeyInterface $key): mixed { $value = $this->get($sessId, $key); $this->delete($sessId, $key); return $value; }
+	public function consumeOrDefault(string $sessId, SessionKeyInterface $key, mixed $default = null): mixed
+	{ $value = $this->getOrDefault($sessId, $key, $default); $this->delete($sessId, $key); return $value; }
+	private function assertSessionExists(string $sessId): void { if (!array_key_exists($sessId, $this->sessions)) throw new SessionMissingException(); }
+}

--- a/test-support/Contracts/Session/FakeSessionKey.php
+++ b/test-support/Contracts/Session/FakeSessionKey.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Support\Contracts\Session;
+
+use Webstract\Session\SessionKeyInterface;
+
+class FakeSessionKey implements SessionKeyInterface
+{
+	public function __construct(private readonly string $name) {}
+	public function getName(): string { return $this->name; }
+}

--- a/test-support/Contracts/Storage/Client/FakeClient.php
+++ b/test-support/Contracts/Storage/Client/FakeClient.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Support\Contracts\Storage\Client;
+
+use Aws\Result;
+use Nyholm\Psr7\Response;
+use Nyholm\Psr7\Uri;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\UriInterface;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Webstract\Env\Visitor\ApplicationEnvironmentVarVisitor;
+use Webstract\Env\Visitor\FileStorageEnvironmentVarVisitor;
+use Webstract\Storage\Client\Client;
+use Webstract\Storage\Object\FileObject;
+
+class FakeClient implements Client
+{
+	public bool $shouldThrowOnUpload = false;
+
+	public function __construct(
+		private readonly ApplicationEnvironmentVarVisitor $appEnv,
+		private readonly FileStorageEnvironmentVarVisitor $fsEnv,
+		private readonly LoggerInterface $log,
+	) {}
+
+	public function listObjects(string $prefix): Result { return new Result(['prefix' => $prefix]); }
+	public function upload(FileObject $object): Result
+	{
+		if ($this->shouldThrowOnUpload) throw new RuntimeException('upload failed');
+		return new Result(['object' => $object->getObjectName()]);
+	}
+	public function composeImageUri(FileObject $object): UriInterface { return new Uri('https://example.com/' . $object->getObjectName()); }
+	public function download(FileObject $object): ResponseInterface { return new Response(200, body: $object->getObjectName()); }
+}

--- a/test-support/Contracts/Storage/FakeFileHandler.php
+++ b/test-support/Contracts/Storage/FakeFileHandler.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Support\Contracts\Storage;
+
+use Nyholm\Psr7\Uri;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UploadedFileInterface;
+use Psr\Http\Message\UriInterface;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Webstract\Env\Visitor\ApplicationEnvironmentVarVisitor;
+use Webstract\Env\Visitor\FileStorageEnvironmentVarVisitor;
+use Webstract\Storage\FileHandler;
+use Webstract\Storage\Path;
+
+class FakeFileHandler implements FileHandler
+{
+	public bool $shouldThrowOnUpload = false;
+	public function __construct(
+		private readonly ApplicationEnvironmentVarVisitor $appEnv,
+		private readonly FileStorageEnvironmentVarVisitor $fsEnv,
+		private readonly LoggerInterface $logger,
+	) {}
+	public function listObjectsFromPath(Path $path): array { return [$path->value]; }
+	public function uploadInlineImage(UploadedFileInterface $file): UriInterface
+	{
+		if ($this->shouldThrowOnUpload) throw new RuntimeException('inline upload failed');
+		return new Uri('https://example.com/image.png');
+	}
+	public function resolveImageUri(string $image): UriInterface { return new Uri('https://example.com/' . ltrim($image, '/')); }
+	public function uploadDatabaseBackup(StreamInterface $stream): void {}
+	public function downloadDatabaseBackup(string $filepath): void
+	{
+		if ($filepath === '') throw new RuntimeException('filepath required');
+	}
+}

--- a/test-support/Contracts/TemplateEngine/FakeTemplateEngineRenderer.php
+++ b/test-support/Contracts/TemplateEngine/FakeTemplateEngineRenderer.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Support\Contracts\TemplateEngine;
+
+use RuntimeException;
+use Webstract\TemplateEngine\TemplateEngineRenderer;
+
+class FakeTemplateEngineRenderer implements TemplateEngineRenderer
+{
+	public bool $shouldThrow = false;
+
+	public function render(string $path, array $context): string
+	{
+		if ($this->shouldThrow) {
+			throw new RuntimeException('template render failed');
+		}
+
+		return sprintf('%s::%s', $path, json_encode($context));
+	}
+}

--- a/test/Contracts/DatabaseContractsTest.php
+++ b/test/Contracts/DatabaseContractsTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Contracts;
+
+use RuntimeException;
+use Test\Support\Contracts\Database\FakeDatabaseTransactionManager;
+use Test\Support\Contracts\Database\FakeRepository;
+use Test\TestCase;
+use Webstract\Database\DatabaseRepositoryConnector;
+
+class DatabaseContractsTest extends TestCase
+{
+	public function test_ShouldUpdateTransactionState_WhenBeginCommitAndRollback(): void
+	{
+		$manager = new FakeDatabaseTransactionManager();
+		$this->assertFalse($manager->inTransaction());
+		$this->assertTrue($manager->beginTransaction());
+		$this->assertTrue($manager->inTransaction());
+		$this->assertTrue($manager->commit());
+		$this->assertFalse($manager->inTransaction());
+		$manager->beginTransaction();
+		$this->assertTrue($manager->rollBack());
+		$this->assertFalse($manager->inTransaction());
+	}
+
+	public function test_ShouldThrowException_WhenTransactionOperationsFail(): void
+	{
+		$manager = new FakeDatabaseTransactionManager();
+		$manager->failOnBegin();
+		$this->expectException(RuntimeException::class);
+		$manager->beginTransaction();
+	}
+
+	public function test_ShouldKeepProvidedConnector_WhenRepositoryIsConstructed(): void
+	{
+		$connector = $this->createStub(DatabaseRepositoryConnector::class);
+		$repository = new FakeRepository($connector);
+		$this->assertSame($connector, $repository->connector());
+	}
+
+	public function test_ShouldThrowException_WhenRepositoryOperationFails(): void
+	{
+		$repository = new FakeRepository($this->createStub(DatabaseRepositoryConnector::class));
+		$this->expectException(RuntimeException::class);
+		$repository->run(fn () => new RuntimeException('operation failed'));
+	}
+}

--- a/test/Contracts/RenderingAndPdfContractsTest.php
+++ b/test/Contracts/RenderingAndPdfContractsTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Contracts;
+
+use RuntimeException;
+use Test\Support\Contracts\Pdf\FakePdfGenerator;
+use Test\Support\Contracts\TemplateEngine\FakeTemplateEngineRenderer;
+use Test\Support\Pdf\FakePdfContent;
+use Test\TestCase;
+
+class RenderingAndPdfContractsTest extends TestCase
+{
+	public function test_ShouldRenderTemplateOutput_WhenPathAndContextAreProvided(): void
+	{
+		$renderer = new FakeTemplateEngineRenderer();
+		$this->assertStringContainsString('/template.html', $renderer->render('/template.html', ['a' => 1]));
+	}
+
+	public function test_ShouldThrowException_WhenTemplateRendererFails(): void
+	{
+		$renderer = new FakeTemplateEngineRenderer();
+		$renderer->shouldThrow = true;
+		$this->expectException(RuntimeException::class);
+		$renderer->render('/template.html', []);
+	}
+
+	public function test_ShouldGeneratePdfContent_WhenPdfContentIsValid(): void
+	{
+		$generator = new FakePdfGenerator(new FakeTemplateEngineRenderer());
+		$output = $generator->generateContent(new FakePdfContent('Hello'));
+		$this->assertStringStartsWith('PDF:', $output);
+	}
+
+	public function test_ShouldThrowException_WhenPdfGenerationFails(): void
+	{
+		$generator = new FakePdfGenerator(new FakeTemplateEngineRenderer());
+		$generator->shouldThrow = true;
+		$this->expectException(RuntimeException::class);
+		$generator->generateContent(new FakePdfContent('Hello'));
+	}
+}

--- a/test/Contracts/SessionContractsTest.php
+++ b/test/Contracts/SessionContractsTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Contracts;
+
+use Test\Support\Contracts\Session\FakeKeyValueSessionHandler;
+use Test\Support\Contracts\Session\FakeSessionHandler;
+use Test\Support\Contracts\Session\FakeSessionKey;
+use Test\TestCase;
+use Webstract\Session\Exception\SessionMissingException;
+use Webstract\Session\Exception\SessionValueNotFoundException;
+
+class SessionContractsTest extends TestCase
+{
+	public function test_ShouldSetGetAndConsumeValues_WhenSessionIsInitialized(): void
+	{
+		$key = new FakeSessionKey('identity');
+		$handler = new FakeSessionHandler();
+		$handler->initSession();
+		$handler->set($key, 'abc');
+		$this->assertTrue($handler->has($key));
+		$this->assertSame('abc', $handler->get($key));
+		$this->assertSame('abc', $handler->consume($key));
+		$this->assertFalse($handler->has($key));
+	}
+
+	public function test_ShouldThrowException_WhenSessionValueIsMissing(): void
+	{
+		$handler = new FakeSessionHandler();
+		$handler->initSession();
+		$this->expectException(SessionValueNotFoundException::class);
+		$handler->get(new FakeSessionKey('missing'));
+	}
+
+	public function test_ShouldEnforceSessionId_WhenUsingKeyValueSessionHandler(): void
+	{
+		$handler = new FakeKeyValueSessionHandler();
+		$key = new FakeSessionKey('identity');
+		$sessId = $handler->initSession();
+		$handler->set($sessId, $key, 'value');
+		$this->assertSame('value', $handler->consumeOrDefault($sessId, $key));
+		$this->expectException(SessionMissingException::class);
+		$handler->get('not-found', $key);
+	}
+}

--- a/test/Contracts/StorageContractsTest.php
+++ b/test/Contracts/StorageContractsTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Contracts;
+
+use Nyholm\Psr7\UploadedFile;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Log\NullLogger;
+use RuntimeException;
+use Test\Support\Contracts\Storage\Client\FakeClient;
+use Test\Support\Contracts\Storage\FakeFileHandler;
+use Test\TestCase;
+use Webstract\Env\Visitor\ApplicationEnvironmentVarVisitor;
+use Webstract\Env\Visitor\FileStorageEnvironmentVarVisitor;
+use Webstract\Storage\Path;
+
+class StorageContractsTest extends TestCase
+{
+	public function test_ShouldReturnListedObjects_WhenPathIsProvided(): void
+	{
+		$handler = new FakeFileHandler($this->createStub(ApplicationEnvironmentVarVisitor::class), $this->createStub(FileStorageEnvironmentVarVisitor::class), new NullLogger());
+		$this->assertSame([Path::PROD_IMAGES->value], $handler->listObjectsFromPath(Path::PROD_IMAGES));
+	}
+
+	public function test_ShouldThrowException_WhenInlineUploadFails(): void
+	{
+		$factory = new Psr17Factory();
+		$handler = new FakeFileHandler($this->createStub(ApplicationEnvironmentVarVisitor::class), $this->createStub(FileStorageEnvironmentVarVisitor::class), new NullLogger());
+		$handler->shouldThrowOnUpload = true;
+		$this->expectException(RuntimeException::class);
+		$handler->uploadInlineImage(new UploadedFile($factory->createStream('x'), 1, UPLOAD_ERR_OK, 'img.png', 'image/png'));
+	}
+
+	public function test_ShouldReturnResultAndUri_WhenClientOperationsSucceed(): void
+	{
+		$client = new FakeClient($this->createStub(ApplicationEnvironmentVarVisitor::class), $this->createStub(FileStorageEnvironmentVarVisitor::class), new NullLogger());
+		$result = $client->listObjects('prod/images/');
+		$this->assertSame('prod/images/', $result['prefix']);
+	}
+}


### PR DESCRIPTION
### Motivation

- Add a concise suite of domain-oriented contract tests to make the observable behavior of core interfaces explicit and to provide minimal fake implementers for other tests to depend on. 
- Cover Database, TemplateEngine/PDF, Storage and Session contracts and ensure tests use clear observable assertions and the existing naming convention `test_Should..._When...`.

### Description

- Added contract tests under `test/Contracts/` for Database, Rendering/PDF, Storage and Session that assert return values, state changes and expected exceptions. 
- Implemented minimal fake implementers under `test-support/Contracts/...` for `DatabaseTransactionManager`, `Repository`, `TemplateEngineRenderer`, `PdfGenerator`, `FileHandler`, `Storage\Client\Client`, `SessionHandler` and `KeyValueSessionHandler`. 
- Fakes expose toggles and observable behaviors (exceptions, return values and state) and avoid depending on internal implementation details. 
- Tests follow the repository naming style and exercise both success and failure scenarios (exceptions and invariants such as consume removing a session key).

### Testing

- Attempted `composer install --no-interaction` to install dev dependencies, but the command failed due to outbound network restrictions when downloading packages (GitHub `CONNECT tunnel failed, response 403`).
- Because dependencies were not installed, `./vendor/bin/phpunit test/Contracts` could not be executed since the PHPUnit binary was not available, so the new tests were not run in CI in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2a969c31c8324bfdf1bfa4c9365c6)