### PR TITLE
Add FastRouteRouter tests with route doubles

### DIFF
--- a/test-support/Route/FakeGetUsersRoute.php
+++ b/test-support/Route/FakeGetUsersRoute.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Support\Route;
+
+use Webstract\Request\RequestMethod;
+use Webstract\Route\RouteDefinition;
+
+final class FakeGetUsersRoute implements RouteDefinition
+{
+	public static function getMethod(): RequestMethod
+	{
+		return RequestMethod::GET;
+	}
+
+	public static function getPattern(): string
+	{
+		return '/users/{id:\\d+}';
+	}
+
+	public static function getController(): string
+	{
+		return 'users.show';
+	}
+}

--- a/test-support/Route/FakePostUsersRoute.php
+++ b/test-support/Route/FakePostUsersRoute.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Support\Route;
+
+use Webstract\Request\RequestMethod;
+use Webstract\Route\RouteDefinition;
+
+final class FakePostUsersRoute implements RouteDefinition
+{
+	public static function getMethod(): RequestMethod
+	{
+		return RequestMethod::POST;
+	}
+
+	public static function getPattern(): string
+	{
+		return '/users/{id:\\d+}';
+	}
+
+	public static function getController(): string
+	{
+		return 'users.update';
+	}
+}

--- a/test-support/Route/FakeRouteProvider.php
+++ b/test-support/Route/FakeRouteProvider.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Support\Route;
+
+use Webstract\Route\RouteDefinition;
+use Webstract\Route\RouteProviderInterface;
+
+final class FakeRouteProvider implements RouteProviderInterface
+{
+	/** @param RouteDefinition[] $definitions */
+	public function __construct(private readonly array $definitions)
+	{
+	}
+
+	public function provideRouteDefinitions(): array
+	{
+		return $this->definitions;
+	}
+}

--- a/test-support/Route/FakeRouteResolver.php
+++ b/test-support/Route/FakeRouteResolver.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Support\Route;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Webstract\Route\RouteResolver;
+use Webstract\Route\RouterOutput;
+
+final class FakeRouteResolver implements RouteResolver
+{
+	public ?ServerRequestInterface $receivedRequest = null;
+
+	public function __construct(private readonly RouterOutput $output)
+	{
+	}
+
+	public function resolve(ServerRequestInterface $serverRequest): RouterOutput
+	{
+		$this->receivedRequest = $serverRequest;
+
+		return $this->output;
+	}
+}

--- a/test/Route/FastRouteRouterTest.php
+++ b/test/Route/FastRouteRouterTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Route;
+
+use Nyholm\Psr7\ServerRequest;
+use Test\Support\Route\FakeGetUsersRoute;
+use Test\Support\Route\FakePostUsersRoute;
+use Test\Support\Route\FakeRouteProvider;
+use Test\TestCase;
+use Webstract\Request\RequestMethod;
+use Webstract\Route\Exception\RoutePatternOverrideException;
+use Webstract\Route\FastRouteRouter;
+use Webstract\Route\RouteHandleable;
+use Webstract\Route\RouterOutput;
+use Webstract\Route\RouterOutputProvider;
+
+final class FastRouteRouterTest extends TestCase
+{
+	public function test_ShouldResolveRoute_WhenMethodAndPatternAreValid(): void
+	{
+		$router = $this->createRouter([FakeGetUsersRoute::class], []);
+
+		$output = $router->resolve(new ServerRequest(RequestMethod::GET->value, '/users/42'));
+
+		$this->assertSame('users.show', $output->route::getController());
+		$this->assertSame(['id' => '42'], $output->pathParams);
+	}
+
+	public function test_ShouldReturnRouteNotFound_WhenMethodIsValidButPatternIsInvalid(): void
+	{
+		$router = $this->createRouter([FakeGetUsersRoute::class], []);
+
+		$output = $router->resolve(new ServerRequest(RequestMethod::GET->value, '/unknown'));
+
+		$this->assertSame('route.not.found', $output->route::getController());
+		$this->assertNull($output->pathParams);
+	}
+
+	public function test_ShouldReturnMethodNotAllowed_WhenPatternMatchesButMethodIsInvalid(): void
+	{
+		$router = $this->createRouter([FakeGetUsersRoute::class], []);
+
+		$output = $router->resolve(new ServerRequest(RequestMethod::POST->value, '/users/42'));
+
+		$this->assertSame('method.not.allowed', $output->route::getController());
+		$this->assertNull($output->pathParams);
+	}
+
+	public function test_ShouldExtractRouteParams_WhenRouteContainsPathParameters(): void
+	{
+		$router = $this->createRouter([FakePostUsersRoute::class], []);
+
+		$output = $router->resolve(new ServerRequest(RequestMethod::POST->value, '/users/777'));
+
+		$this->assertSame(['id' => '777'], $output->pathParams);
+	}
+
+	public function test_ShouldThrowException_WhenCustomRouteOverridesFrameworkPattern(): void
+	{
+		$router = $this->createRouter([FakeGetUsersRoute::class], [FakeGetUsersRoute::class]);
+
+		$this->expectException(RoutePatternOverrideException::class);
+		$this->expectExceptionMessage('has pattern `/users/{id:\\d+}` that is reserved by framework.');
+
+		$router->resolve(new ServerRequest(RequestMethod::GET->value, '/users/12'));
+	}
+
+	/** @param array<class-string<\Webstract\Route\RouteDefinition>> $baseRoutes */
+	/** @param array<class-string<\Webstract\Route\RouteDefinition>> $customRoutes */
+	private function createRouter(array $baseRoutes, array $customRoutes): FastRouteRouter
+	{
+		return new FastRouteRouter(
+			new FakeRouteProvider($customRoutes),
+			new class() extends RouterOutputProvider {
+				public function routeNotFound(): RouterOutput
+				{
+					return new RouterOutput(new class() implements RouteHandleable {
+						public static function getController(): string
+						{
+							return 'route.not.found';
+						}
+					}, null);
+				}
+
+				public function methodNotAllowed(): RouterOutput
+				{
+					return new RouterOutput(new class() implements RouteHandleable {
+						public static function getController(): string
+						{
+							return 'method.not.allowed';
+						}
+					}, null);
+				}
+			},
+			new FakeRouteProvider($baseRoutes)
+		);
+	}
+}


### PR DESCRIPTION
### Motivation
- Add coverage for the router resolver to validate behavior for valid/invalid method and pattern combinations, path parameter extraction and reserved-pattern override errors. 
- Provide lightweight test doubles to inject route definitions and control resolver outputs during tests. 
- Skill usage: no external skill was used because this change is a straightforward test addition and small test-support doubles.

### Description
- Added `test/Route/FastRouteRouterTest.php` with tests for: valid route resolution, route not found (pattern mismatch), method not allowed (method mismatch), path parameter extraction, and framework pattern override error. 
- Added route doubles `test-support/Route/FakeGetUsersRoute.php` and `test-support/Route/FakePostUsersRoute.php` implementing `RouteDefinition` for GET/POST dynamic `/users/{id}` patterns. 
- Added `test-support/Route/FakeRouteProvider.php` implementing `RouteProviderInterface` to supply route lists to the router in tests. 
- Added `test-support/Route/FakeRouteResolver.php` implementing `RouteResolver` to allow injecting a prebuilt `RouterOutput` and capturing the received request.

### Testing
- Ran PHP syntax checks with `php -l` on the new files which all returned no syntax errors. 
- Attempted to run the test suite with `vendor/bin/phpunit test/Route/FastRouteRouterTest.php` but it failed in this environment because dependencies are not installed (`vendor/bin/phpunit` not present). 
- All added files were validated with `php -l` and passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2a986d3d88324a7a4eb00c967dbed)