### PR TITLE
Expand controller tests: middleware contract, Api edge-cases, async render behavior and download/redirect assertions

### DIFF
--- a/test/Controller/ActionControllerTest.php
+++ b/test/Controller/ActionControllerTest.php
@@ -44,5 +44,7 @@ class ActionControllerTest extends TestCase
 
 		$this->assertEquals($expectedResponse, $controllerResponse);
 		$this->assertEquals('', (string) $controllerResponse->getBody());
+		$this->assertSame(303, $controllerResponse->getStatusCode());
+		$this->assertSame('/', $controllerResponse->getHeaderLine('Location'));
 	}
 }

--- a/test/Controller/ApiControllerTest.php
+++ b/test/Controller/ApiControllerTest.php
@@ -4,12 +4,16 @@ declare(strict_types=1);
 
 namespace Test\Controller;
 
+use JsonSerializable;
 use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
 use Test\Support\Controller\FakeApiControllerWithContent;
 use Test\Support\Controller\FakeApiControllerWithEmptyContent;
 use Test\Support\Controller\FakeApiControllerWithoutContent;
 use Test\TestCase;
+use Webstract\Controller\ApiController;
 
 class ApiControllerTest extends TestCase
 {
@@ -64,43 +68,93 @@ class ApiControllerTest extends TestCase
 		$this->assertEquals('{"message":"Hello, World!"}', (string) $controllerResponse->getBody());
 	}
 
-	
+	public function test_middlewaresContract_ShouldKeepOrderTypeAndDefaultEmptyList(): void
+	{
+		$serverRequest = $this->createStub(ServerRequestInterface::class);
+		$middlewareA = $this->createStub(MiddlewareInterface::class);
+		$middlewareB = $this->createStub(MiddlewareInterface::class);
+		$response = self::$psr17Factory->createResponse();
+		$stream = self::$psr17Factory->createStream();
+
+		$controllerWithDefault = new class ($response, $stream) extends ApiController {
+			public function middlewares(): array
+			{
+				return [];
+			}
+
+			public function handle(ServerRequestInterface $serverRequest): ResponseInterface
+			{
+				return $this->createJsonResponse();
+			}
+		};
+
+		$controllerWithMiddlewares = new class ($response, $stream, $middlewareA, $middlewareB) extends ApiController {
+			/** @var MiddlewareInterface[] */
+			private array $middlewares;
+
+			public function __construct(ResponseInterface $response, \Psr\Http\Message\StreamInterface $stream, MiddlewareInterface ...$middlewares)
+			{
+				parent::__construct($response, $stream);
+				$this->middlewares = $middlewares;
+			}
+
+			public function middlewares(): array
+			{
+				return $this->middlewares;
+			}
+
+			public function handle(ServerRequestInterface $serverRequest): ResponseInterface
+			{
+				return $this->createJsonResponse();
+			}
+		};
+
+		$this->assertSame([], $controllerWithDefault->middlewares());
+		$this->assertSame([$middlewareA, $middlewareB], $controllerWithMiddlewares->middlewares());
+		$this->assertContainsOnlyInstancesOf(MiddlewareInterface::class, $controllerWithMiddlewares->middlewares());
+		$controllerWithDefault->handle($serverRequest);
+	}
+
+	public function test_createJsonResponse_ShouldHandleEdgeCasePayloads(): void
+	{
+		$response = self::$psr17Factory->createResponse();
+		$stream = self::$psr17Factory->createStream();
+
+		$jsonSerializable = new class implements JsonSerializable {
+			public function jsonSerialize(): mixed
+			{
+				return ['status' => 'success'];
+			}
+		};
+
+		$controller = new class ($response, $stream) extends ApiController {
+			public function middlewares(): array { return []; }
+			public function handle(ServerRequestInterface $serverRequest): ResponseInterface { return $this->createJsonResponse(); }
+			public function exposeCreateJsonResponse(array|JsonSerializable|null $content = null, int $statusCode = 200): ResponseInterface
+			{
+				return $this->createJsonResponse($content, $statusCode);
+			}
+		};
+
+		$this->assertSame('', (string) $controller->exposeCreateJsonResponse([])->getBody());
+		$this->assertSame('{"status":"success"}', (string) $controller->exposeCreateJsonResponse($jsonSerializable)->getBody());
+	}
+
+	public function test_createJsonResponse_ShouldThrowForInvalidTypes(): void
+	{
+		$response = self::$psr17Factory->createResponse();
+		$stream = self::$psr17Factory->createStream();
+
+		$controller = new class ($response, $stream) extends ApiController {
+			public function middlewares(): array { return []; }
+			public function handle(ServerRequestInterface $serverRequest): ResponseInterface { return $this->createJsonResponse(); }
+			public function exposeCreateJsonResponseUnsafe(mixed $content): ResponseInterface
+			{
+				return $this->createJsonResponse($content);
+			}
+		};
+
+		$this->expectException(\TypeError::class);
+		$controller->exposeCreateJsonResponseUnsafe('invalid');
+	}
 }
-
-// test('should works properly', function () {
-// 	$pdfGenerator = new DompdfPdfGenerator(new TwigTemplateEngineRenderer());
-	
-// 	$controller = new FakeApiController($this->response, $this->stream, $pdfGenerator);
-
-// 	$result = $controller->handle($this->serverRequest);
-
-// 	expect($result)->toBeInstanceOf(ResponseInterface::class);
-// 	expect((string) $result->getBody())->toBe('{"message":"Hello, World!"}');
-// 	expect($result->getHeaders())->toBe(['Content-Type' => ['application/json']]);
-// 	expect($result->getStatusCode())->toBe(200);
-// });
-
-// test('createJsonResponse handles expected entries gracefully', function (mixed $expectedContent, string $expectedBodyResult) {
-// 	$pdfGenerator = new DompdfPdfGenerator(new TwigTemplateEngineRenderer());
-	
-// 	$controller = new FakeApiController($this->response, $this->stream, $pdfGenerator);
-
-// 	$result = $controller->testCreateJsonResponse($expectedContent);
-
-// 	expect($result)->toBeInstanceOf(ResponseInterface::class);
-// 	expect((string) $result->getBody())->toBe($expectedBodyResult);
-// 	expect($result->getHeaders())->toBe(['Content-Type' => ['application/json']]);
-// 	expect($result->getStatusCode())->toBe(200);
-// })->with([
-// 	[null, ''],
-// 	[['number' => 1], '{"number":1}'],
-// 	[new JsonSerializableClass(), '{"status":"success"}']
-// ]);
-
-// test('createJsonResponse throw exception when value not handable', function (mixed $expectedContent) {
-// 	$pdfGenerator = new DompdfPdfGenerator(new TwigTemplateEngineRenderer());
-	
-// 	$controller = new FakeApiController($this->response, $this->stream, $pdfGenerator);
-
-// 	$controller->testCreateJsonResponse($expectedContent);
-// })->with([1, '', '1', new stdClass()])->throws(TypeError::class);

--- a/test/Controller/AsyncComponentControllerTest.php
+++ b/test/Controller/AsyncComponentControllerTest.php
@@ -17,6 +17,7 @@ use Webstract\Controller\AsyncComponentController;
 use Webstract\Controller\Traits\AsyncRedirectableResponse;
 use Webstract\Session\SessionHandler;
 use Webstract\TemplateEngine\TemplateEngineRenderer;
+use Webstract\Web\AsyncComponent;
 
 class AsyncComponentControllerTest extends TestCase
 {
@@ -97,5 +98,59 @@ class AsyncComponentControllerTest extends TestCase
 
 		$this->assertEquals($expectedResponse, $controllerResponse);
 		$this->assertEquals('<h1>RENDERABLE</h1>', (string) $controllerResponse->getBody());
+	}
+
+	public function test_createHtmlResponse_ShouldRenderWhenComponentAllowsRendering(): void
+	{
+		$response = self::$psr17Factory->createResponse();
+		$stream = self::$psr17Factory->createStream();
+		$session = $this->createStub(SessionHandler::class);
+		$serverRequest = $this->createStub(ServerRequestInterface::class);
+		$templateEngine = $this->createMock(TemplateEngineRenderer::class);
+		$templateEngine->expects($this->once())->method('render')->with('/fake/path.html', ['name' => 'John'])->willReturn('<h1>rendered</h1>');
+
+		$component = $this->createMock(AsyncComponent::class);
+		$component->method('shouldRendered')->willReturn(true);
+		$component->method('htmlPath')->willReturn('/fake/path.html');
+		$component->method('context')->willReturn(['name' => 'John']);
+
+		$controller = new class ($response, $stream, $session, $templateEngine, $component) extends AsyncComponentController {
+			public function __construct($response, $stream, $session, $templateEngine, private readonly AsyncComponent $component) { parent::__construct($response, $stream, $session, $templateEngine); }
+			public function middlewares(): array { return []; }
+			public function handle(ServerRequestInterface $serverRequest): ResponseInterface { return $this->createHtmlResponse($this->component); }
+		};
+
+		$controllerResponse = $controller->handle($serverRequest);
+		$this->assertSame(200, $controllerResponse->getStatusCode());
+		$this->assertSame('text/html; charset=utf-8', $controllerResponse->getHeaderLine('Content-Type'));
+		$this->assertSame('<h1>rendered</h1>', (string) $controllerResponse->getBody());
+	}
+
+	public function test_createHtmlResponse_ShouldNotRenderWhenComponentDisablesRendering(): void
+	{
+		$response = self::$psr17Factory->createResponse();
+		$stream = self::$psr17Factory->createStream();
+		$session = $this->createStub(SessionHandler::class);
+		$serverRequest = $this->createStub(ServerRequestInterface::class);
+		$templateEngine = $this->createMock(TemplateEngineRenderer::class);
+		$templateEngine->expects($this->never())->method('render');
+		$tempFile = tempnam(sys_get_temp_dir(), 'async-component');
+		file_put_contents($tempFile, '<h1>raw</h1>');
+
+		$component = $this->createMock(AsyncComponent::class);
+		$component->method('shouldRendered')->willReturn(false);
+		$component->method('htmlPath')->willReturn($tempFile);
+		$component->method('context')->willReturn([]);
+
+		$controller = new class ($response, $stream, $session, $templateEngine, $component) extends AsyncComponentController {
+			public function __construct($response, $stream, $session, $templateEngine, private readonly AsyncComponent $component) { parent::__construct($response, $stream, $session, $templateEngine); }
+			public function middlewares(): array { return []; }
+			public function handle(ServerRequestInterface $serverRequest): ResponseInterface { return $this->createHtmlResponse($this->component); }
+		};
+
+		$controllerResponse = $controller->handle($serverRequest);
+		$this->assertSame(200, $controllerResponse->getStatusCode());
+		$this->assertSame('<h1>raw</h1>', (string) $controllerResponse->getBody());
+		unlink($tempFile);
 	}
 }

--- a/test/Controller/DownloadableActionControllerTest.php
+++ b/test/Controller/DownloadableActionControllerTest.php
@@ -50,6 +50,7 @@ class DownloadableActionControllerTest extends TestCase
 
 		$this->assertEquals($expectedResponse, $controllerResponse);
 		$this->assertEquals('', (string) $controllerResponse->getBody());
+		$this->assertSame(500, $controllerResponse->getStatusCode());
 	}
 
 	public function test_AssertMethod_createDownloadResponse_Return500WhenFileHaveNoExtension(): void
@@ -66,6 +67,7 @@ class DownloadableActionControllerTest extends TestCase
 
 		$this->assertEquals($expectedResponse, $controllerResponse);
 		$this->assertEquals('', (string) $controllerResponse->getBody());
+		$this->assertSame(500, $controllerResponse->getStatusCode());
 	}
 
 	public function test_AssertMethod_createDownloadResponse_ReturnDownloadableAttachment(): void
@@ -87,6 +89,8 @@ class DownloadableActionControllerTest extends TestCase
 
 		$this->assertEquals($expectedResponse, $controllerResponse);
 		$this->assertEquals('content of file with content', (string) $controllerResponse->getBody());
+		$this->assertSame(200, $controllerResponse->getStatusCode());
+		$this->assertSame('attachment; filename=\"file-with-content.txt\"', $controllerResponse->getHeaderLine('Content-Disposition'));
 	}
 
 	public function test_AssertMethod_createPdfContentDownloadableResponse_ReturnDownloadablePdfAttachment(): void
@@ -120,5 +124,7 @@ class DownloadableActionControllerTest extends TestCase
 			%%EOF
 
 			PDF, (string) $controllerResponse->getBody());
+		$this->assertSame(200, $controllerResponse->getStatusCode());
+		$this->assertSame('application/pdf', $controllerResponse->getHeaderLine('Content-Type'));
 	}
 }


### PR DESCRIPTION
### Motivation
- Increase confidence in controller contracts by explicitly validating `middlewares()` (default value, order and type) and prevent fake test classes from masking contract failures.
- Cover edge-case payloads in `ApiController::createJsonResponse` to ensure correct behavior for empty arrays, `JsonSerializable` objects and invalid types.
- Assert expected status codes and response headers for redirect and downloadable responses to avoid regressions in HTTP semantics.
- Verify `AsyncComponentController::createHtmlResponse` both when components should be rendered and when they should return raw file contents.

### Description
- Added middleware-contract test in `test/Controller/ApiControllerTest.php` that uses anonymous controllers to assert default `[]`, preservation of middleware order and that returned items are instances of `MiddlewareInterface`.
- Extended `ApiController` tests in `test/Controller/ApiControllerTest.php` to cover empty-array payloads, `JsonSerializable` payloads and an invalid-type case that should throw `TypeError` via an `exposeCreateJsonResponseUnsafe` helper on an anonymous controller.
- Strengthened redirect/download assertions in `test/Controller/ActionControllerTest.php` and `test/Controller/DownloadableActionControllerTest.php` to explicitly assert status codes and headers such as `Location`, `Content-Disposition` and `Content-Type`.
- Added two tests to `test/Controller/AsyncComponentControllerTest.php` that exercise rendering and non-rendering paths by mocking `TemplateEngineRenderer` (using `expects($this->once())` and `expects($this->never())`), mocking `AsyncComponent`, and using a temporary file to validate the raw-content path.
- Modified files: `test/Controller/ApiControllerTest.php`, `test/Controller/AsyncComponentControllerTest.php`, `test/Controller/ActionControllerTest.php`, and `test/Controller/DownloadableActionControllerTest.php`.

### Testing
- Attempted to run the focused PHPUnit suite with `vendor/bin/phpunit test/Controller/ApiControllerTest.php test/Controller/AsyncComponentControllerTest.php test/Controller/ActionControllerTest.php test/Controller/DownloadableActionControllerTest.php`, but `vendor/bin/phpunit` was not present in the environment so the command could not run.
- Ran `composer install --no-interaction` to install dev dependencies, but installation failed due to network/GitHub access errors (`CONNECT tunnel failed, response 403`), preventing PHPUnit from being installed and preventing test execution.
- No automated tests were executed to completion in this environment due to the dependency download failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2a987ca648324aa08e4f1a4000814)