### PR TITLE
Expand Web tests for context contracts and asset path validation

### DIFF
--- a/test/Web/AsyncComponentTest.php
+++ b/test/Web/AsyncComponentTest.php
@@ -2,21 +2,36 @@
 
 declare(strict_types=1);
 
+namespace Test\Web;
+
 use Test\Support\Web\FakeAsyncComponent\FakeNonRenderableAsyncComponent;
 use Test\TestCase;
 
-use function PHPUnit\Framework\throwException;
-
 class AsyncComponentTest extends TestCase
 {
-	public function test_ContextShouldReturnExpectedValue(): void
+	public function test_AsyncComponentKeepsSpecificContextKeyAndComponentContextBehavior(): void
 	{
-		$expectedContext = [
-			'component' => new FakeNonRenderableAsyncComponent('title')
-		];
+		$component = new FakeNonRenderableAsyncComponent('title');
+		$context = $component->context();
+
+		$this->assertSame('component', $component->contextKey());
+		$this->assertArrayHasKey($component->contextKey(), $context);
+		$this->assertSame($component, $context[$component->contextKey()]);
+	}
+
+	public function test_AsyncComponentMaintainsSpecificShouldRenderedBehavior(): void
+	{
 		$component = new FakeNonRenderableAsyncComponent('title');
 
-		$this->assertEquals($expectedContext, $component->context());
-		$this->assertEquals('component', $component->contextKey());
+		$this->assertFalse($component->shouldRendered());
+	}
+
+	public function test_AssetPathsRespectNullableAndExpectedFormat(): void
+	{
+		$component = new FakeNonRenderableAsyncComponent('title');
+
+		$this->assertNull($component->cssPath());
+		$this->assertNull($component->jsPath());
+		$this->assertStringEndsWith('.html', $component->htmlPath());
 	}
 }

--- a/test/Web/ContentTest.php
+++ b/test/Web/ContentTest.php
@@ -4,20 +4,31 @@ declare(strict_types=1);
 
 namespace Test\Web;
 
-use Exception;
 use Test\Support\Web\FakeContent\FakeContent;
 use Test\TestCase;
 
 class ContentTest extends TestCase
 {
-	public function test_ContextShouldReturnExpectedValues(): void
+	public function test_ContextAlwaysContainsKeyFromContextKey(): void
 	{
-		$expectedContext = [
-			'content' => new FakeContent(['1', '2'], 'paragraph'),
-		];
+		$content = new FakeContent(['1', '2'], 'paragraph');
+		$context = $content->context();
+
+		$this->assertArrayHasKey($content->contextKey(), $context);
+		$this->assertSame($content, $context[$content->contextKey()]);
+	}
+
+	public function test_AssetPathsRespectNullableAndExpectedFormat(): void
+	{
 		$content = new FakeContent(['1', '2'], 'paragraph');
 
-		$this->assertEquals($expectedContext, $content->context());
-		$this->assertEquals('content', $content->contextKey());
+		$this->assertIsString($content->cssPath());
+		$this->assertStringEndsWith('.css', (string) $content->cssPath());
+
+		$this->assertIsString($content->jsPath());
+		$this->assertStringEndsWith('.js', (string) $content->jsPath());
+
+		$this->assertIsString($content->htmlPath());
+		$this->assertStringEndsWith('.html', $content->htmlPath());
 	}
 }

--- a/test/Web/PageTest.php
+++ b/test/Web/PageTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+namespace Test\Web;
+
 use Test\Support\Web\FakeComponent\FakeComponent;
 use Test\Support\Web\FakeContent\FakeContent;
 use Test\Support\Web\FakePage\FakePage;
@@ -9,15 +11,26 @@ use Test\TestCase;
 
 class PageTest extends TestCase
 {
-	public function test_ContextShouldReturnExpectedValue(): void
+	public function test_PageExposesContentCompositionWithoutBreakingContentContextContract(): void
 	{
-		$expectedContext = [
-			'page' => new FakePage(new FakeContent(['1','2'], 'paragraph'), new FakeComponent('text')),
-			'content' => new FakeContent(['1','2'], 'paragraph'),
-			'fakeComponent' => new FakeComponent('text'),
-		];
-		$page = new FakePage(new FakeContent(['1','2'], 'paragraph'), new FakeComponent('text'));
+		$content = new FakeContent(['1', '2'], 'paragraph');
+		$page = new FakePage($content, new FakeComponent('text'));
+		$context = $page->context();
 
-		$this->assertEquals($expectedContext, $page->context());
+		$this->assertArrayHasKey('page', $context);
+		$this->assertSame($page, $context['page']);
+
+		$this->assertArrayHasKey($content->contextKey(), $context);
+		$this->assertSame($content, $context[$content->contextKey()]);
+		$this->assertSame($content->context(), [$content->contextKey() => $context[$content->contextKey()]]);
+	}
+
+	public function test_PageAssetPathsHaveExpectedFormat(): void
+	{
+		$page = new FakePage(new FakeContent(['1', '2'], 'paragraph'), new FakeComponent('text'));
+
+		$this->assertStringEndsWith('.css', $page->cssPath());
+		$this->assertStringEndsWith('.js', $page->jsPath());
+		$this->assertStringEndsWith('.html', $page->htmlPath());
 	}
 }


### PR DESCRIPTION
### Motivation
- Ensure `context()` implementations always include the key returned by `contextKey()` to preserve view composition contracts.
- Verify that `Page` composition with `Content` does not break `Content`'s context contract when merging contexts.
- Confirm `AsyncComponent` preserves its async-specific contract (`contextKey()` = `component` and `shouldRendered()` behavior).
- Validate `cssPath/jsPath/htmlPath` follow expected nullability and filename extension conventions.

### Description
- Expanded `test/Web/ContentTest.php` to assert that `context()` contains the key from `contextKey()` and to check `cssPath`, `jsPath`, and `htmlPath` formats and nullability using `assertIsString`, `assertNull`, and `assertStringEndsWith` where appropriate.
- Expanded `test/Web/PageTest.php` to assert `Page` exposes itself under the `page` key, preserves the `Content` context contract when composing contexts, and to validate page asset path extensions.
- Expanded `test/Web/AsyncComponentTest.php` to assert async components return the specific `contextKey()` value, maintain `shouldRendered()` behavior, and respect nullable `css/js` paths and `.html` extension for `htmlPath()`.

### Testing
- Ran `vendor/bin/phpunit test/Web` which failed because the `vendor/bin/phpunit` binary is not present in this environment.
- Ran `phpunit test/Web` which failed because the `phpunit` command is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2a989f09c8324a0e236e4ab8c9d7c)