### PR TITLE
Add EnvVarHandler and EnvVarVisitor unit tests

### DIFF
--- a/test/Environment/EnvVarHandlerTest.php
+++ b/test/Environment/EnvVarHandlerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Environment;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use Test\Support\Environment\FakeEnvVar;
+use Test\TestCase;
+use Webstract\Env\EnvVarHandler;
+use Webstract\Env\EnvironmentVarLoaderInterface;
+use Webstract\Env\Exception\EnvironmentVarNotResolvedException;
+
+#[CoversClass(EnvVarHandler::class)]
+#[RunInSeparateProcess]
+final class EnvVarHandlerTest extends TestCase
+{
+	public function test_getVar_ShouldReturnValueWhenEnvVarExists(): void
+	{
+		$loader = $this->createMock(EnvironmentVarLoaderInterface::class);
+		$loader->expects($this->once())->method('load');
+
+		$_ENV[FakeEnvVar::FOO->getName()] = 'bar';
+
+		$handler = new EnvVarHandler($loader);
+
+		$this->assertSame('bar', $handler->getVar(FakeEnvVar::FOO));
+	}
+
+	public function test_getVar_ShouldThrowWhenEnvVarDoesNotExist(): void
+	{
+		$loader = $this->createMock(EnvironmentVarLoaderInterface::class);
+		$loader->expects($this->once())->method('load');
+
+		unset($_ENV[FakeEnvVar::FOO->getName()]);
+		putenv(FakeEnvVar::FOO->getName());
+
+		$handler = new EnvVarHandler($loader);
+
+		$this->expectException(EnvironmentVarNotResolvedException::class);
+		$this->expectExceptionMessage('Environment variable `FOO` was not resolved.');
+
+		$handler->getVar(FakeEnvVar::FOO);
+	}
+
+	public function test_getVarOrDefault_ShouldRespectNullAndNonNullDefaults(): void
+	{
+		$loader = $this->createMock(EnvironmentVarLoaderInterface::class);
+		$loader->expects($this->once())->method('load');
+
+		unset($_ENV[FakeEnvVar::FOO->getName()]);
+		putenv(FakeEnvVar::FOO->getName());
+
+		$handler = new EnvVarHandler($loader);
+
+		$this->assertNull($handler->getVarOrDefault(FakeEnvVar::FOO, null));
+		$this->assertSame('fallback', $handler->getVarOrDefault(FakeEnvVar::FOO, 'fallback'));
+	}
+}

--- a/test/Environment/EnvVarVisitorTest.php
+++ b/test/Environment/EnvVarVisitorTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Environment;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Test\TestCase;
+use Webstract\Env\EnvVar;
+use Webstract\Env\EnvVarVisitor;
+use Webstract\Env\EnvironmentHandlerInterface;
+
+#[CoversClass(EnvVarVisitor::class)]
+final class EnvVarVisitorTest extends TestCase
+{
+	public function test_ApplicationDatabaseLogAndFileStorageVisitors_ShouldMapExpectedEnvironmentVars(): void
+	{
+		$environmentHandler = new class implements EnvironmentHandlerInterface {
+			/** @var array<string, string> */
+			private array $values = [
+				'APP_NAME' => 'webstract',
+				'ENVIRONMENT' => 'dev',
+				'DB_TYPE' => 'pgsql',
+				'DB_HOST' => 'database.local',
+				'DB_PORT' => '5432',
+				'DB_NAME' => 'webstract_db',
+				'DB_USER' => 'db-user',
+				'DB_PASS' => 'db-pass',
+				'LOG_API_KEY' => 'log-key',
+				'FILE_STORAGE_PUBLIC_API_KEY' => 'public-key',
+				'FILE_STORAGE_SECRET_API_KEY' => 'secret-key',
+				'FILE_STORAGE_BUCKET_REGION' => 'sa-saopaulo-1',
+				'FILE_STORAGE_BUCKET_NAME' => 'bucket-name',
+				'FILE_STORAGE_BUCKET_NAMESPACE' => 'namespace',
+			];
+
+			public function getVar(\Webstract\Env\EnvironmentVarInterface $envVar): string
+			{
+				return $this->values[$envVar->getName()];
+			}
+
+			public function getVarOrDefault(\Webstract\Env\EnvironmentVarInterface $envVar, ?string $defaultValue): ?string
+			{
+				return $this->values[$envVar->getName()] ?? $defaultValue;
+			}
+		};
+
+		$visitor = new EnvVarVisitor($environmentHandler);
+
+		$this->assertSame('webstract', $visitor->getAppName());
+		$this->assertTrue($visitor->isDevEnv());
+		$this->assertSame('database.local', $visitor->getDatabaseHost());
+		$this->assertSame('webstract_db', $visitor->getDatabaseName());
+		$this->assertSame('db-user', $visitor->getDatabaseUser());
+		$this->assertSame('pgsql', $visitor->getDatabaseType());
+		$this->assertSame('5432', $visitor->getDatabasePort());
+		$this->assertSame('db-pass', $visitor->getDatabasePassword());
+		$this->assertSame('pgsql:host=database.local;port=5432;dbname=webstract_db;user=db-user;password=db-pass', $visitor->getDatabaseDsn());
+
+		$this->assertSame('log-key', $visitor->getLogApiKey());
+
+		$this->assertSame('public-key', $visitor->getFileStoragePublicApiKey());
+		$this->assertSame('secret-key', $visitor->getFileStorageSecretApiKey());
+		$this->assertSame('sa-saopaulo-1', $visitor->getFileStorageBucketRegion());
+		$this->assertSame('bucket-name', $visitor->getFileStorageBucketName());
+		$this->assertSame('namespace', $visitor->getFileStorageBucketNamespace());
+	}
+
+	public function test_isDevEnv_ShouldDefaultToProdWhenEnvironmentVarIsMissing(): void
+	{
+		$environmentHandler = $this->createMock(EnvironmentHandlerInterface::class);
+		$environmentHandler
+			->expects($this->once())
+			->method('getVarOrDefault')
+			->with(EnvVar::ENVIRONMENT, 'prod')
+			->willReturn('prod');
+
+		$visitor = new EnvVarVisitor($environmentHandler);
+
+		$this->assertFalse($visitor->isDevEnv());
+	}
+}


### PR DESCRIPTION
### Motivation
- Improve test coverage for environment handling by validating `EnvVarHandler` behaviors for existing and missing variables and `getVarOrDefault` semantics. 
- Ensure `EnvVarVisitor` correctly maps environment variables for Application, Database, Log and FileStorage concerns, including DSN composition. 
- Verify `isDevEnv()` fallback behavior when the `ENVIRONMENT` variable is absent. 

### Description
- Added `test/Environment/EnvVarHandlerTest.php` with tests for `getVar()` when the variable exists, `getVar()` raising `EnvironmentVarNotResolvedException` when missing, and `getVarOrDefault()` with `null` and non-null defaults. 
- Added `test/Environment/EnvVarVisitorTest.php` that uses an anonymous fake and a mock of `EnvironmentHandlerInterface` to assert mapping for `getAppName()`, `isDevEnv()`, all `getDatabase*()` methods (and `getDatabaseDsn()`), `getLogApiKey()` and `getFileStorage*()` methods. 
- Tests use `FakeEnvVar` and a mocked `EnvironmentVarLoaderInterface` to control loader behavior and `#[RunInSeparateProcess]` where needed. 
- New tests are covered by `#[CoversClass(...)]` attributes to link them to `EnvVarHandler` and `EnvVarVisitor`. 

### Testing
- Attempted to run `composer test -- test/Environment`, but the run failed because `vendor/bin/phpunit` was not available in the environment. 
- Attempted `composer install`, but dependency installation failed due to network access errors downloading from GitHub (`CONNECT tunnel failed, response 403`), so PHPUnit could not be installed and tests could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2a98d51788324a78a0c646e6c5fa3)