### PR TITLE
Add CommandProvider tests and validate command class contract

### DIFF
--- a/src/Cli/CommandProvider.php
+++ b/src/Cli/CommandProvider.php
@@ -56,7 +56,8 @@ final class CommandProvider implements CommandProviderInterface
 		$newCommands = array_keys($this->commands);
 
 		foreach ($newCommands as $newCommand) {
-			if ($newCommand instanceof Command) {
+			$commandClass = $this->commands[$newCommand];
+			if (is_subclass_of($commandClass, Command::class)) {
 				continue;
 			}
 

--- a/test/Cli/CommandProviderTest.php
+++ b/test/Cli/CommandProviderTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Cli;
+
+use Test\TestCase;
+use Webstract\Cli\Command;
+use Webstract\Cli\CommandProvider;
+
+final class CommandProviderTest extends TestCase
+{
+	public function test_ShouldRegisterValidCommand(): void
+	{
+		$provider = new CommandProvider([
+			'custom-command' => FakeCommand::class,
+		]);
+
+		$this->assertSame(FakeCommand::class, $provider->resolveFromArgv1('custom-command'));
+	}
+
+	public function test_ShouldThrowWhenRegisteringTypeThatDoesNotImplementExpectedContract(): void
+	{
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('Attempt to registry command `invalid-command` that dont implement expected interface.');
+
+		new CommandProvider([
+			'invalid-command' => \stdClass::class,
+		]);
+	}
+
+	public function test_ShouldResolveExistingCommand(): void
+	{
+		$provider = new CommandProvider();
+
+		$this->assertSame(
+			\Webstract\Cli\Commands\DatabaseMigrate::class,
+			$provider->resolveFromArgv1('database-migrate')
+		);
+	}
+
+	public function test_ShouldReturnNullWhenResolvingNonExistingCommand(): void
+	{
+		$provider = new CommandProvider();
+
+		$this->assertNull($provider->resolveFromArgv1('unknown-command'));
+	}
+
+	public function test_ShouldKeepRegisteredCommandsOrderAndConsistency(): void
+	{
+		$provider = new CommandProvider([
+			'custom-first' => FakeCommand::class,
+			'custom-second' => FakeOtherCommand::class,
+		]);
+
+		$commands = $this->extractCommands($provider);
+
+		$this->assertSame([
+			'database-create-migration',
+			'database-migrate',
+			'database-rollback',
+			'database-backup',
+			'database-restore',
+			'custom-first',
+			'custom-second',
+		], array_keys($commands));
+
+		$this->assertSame(FakeCommand::class, $commands['custom-first']);
+		$this->assertSame(FakeOtherCommand::class, $commands['custom-second']);
+	}
+
+	/** @return array<string, class-string<Command>> */
+	private function extractCommands(CommandProvider $provider): array
+	{
+		$reflection = new \ReflectionClass($provider);
+		$property = $reflection->getProperty('commands');
+		$property->setAccessible(true);
+
+		/** @var array<string, class-string<Command>> $commands */
+		$commands = $property->getValue($provider);
+
+		return $commands;
+	}
+}
+
+final class FakeCommand extends Command
+{
+	public function preExecutionHook(): void {}
+	public function command(): string
+	{
+		return 'echo fake';
+	}
+	public function postExecutionHook(): void {}
+	public function onFailedExecutionHook(): void {}
+}
+
+final class FakeOtherCommand extends Command
+{
+	public function preExecutionHook(): void {}
+	public function command(): string
+	{
+		return 'echo other';
+	}
+	public function postExecutionHook(): void {}
+	public function onFailedExecutionHook(): void {}
+}


### PR DESCRIPTION
### Motivation

- Ensure `CommandProvider` enforces that registered entries are valid `Webstract\Cli\Command` subclasses and to cover expected behaviors via unit tests.

### Description

- Added `test/Cli/CommandProviderTest.php` with five scenarios: valid registration, invalid-type registration (should throw), resolve existing command, resolve non-existing command (null), and order/consistency of the merged command list.
- Fixed `CommandProvider::throwIfCommandIsNotInstanceOfCliCommand()` to validate the configured class strings using `is_subclass_of($commandClass, Command::class)` instead of incorrectly checking the array key.
- Tests include local `FakeCommand` and `FakeOtherCommand` classes extending `Webstract\Cli\Command` to exercise registration and ordering logic.

### Testing

- Attempted to run `vendor/bin/phpunit test/Cli/CommandProviderTest.php`, but it failed because `vendor/bin/phpunit` is not present in the environment.
- Attempted to run `phpunit test/Cli/CommandProviderTest.php` (global binary), but it failed because there is no global `phpunit` available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2a9912a7483248f258d32a73c3263)