### PR TITLE
Add local infrastructure tests and isolate optional integration suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,5 +20,8 @@ jobs:
       - name: Install Dependencies
         run: composer install --no-interaction --prefer-dist --optimize-autoloader
 
-      - name: Tests
+      - name: Unit Tests
         run: composer test
+
+      - name: Infrastructure Tests
+        run: composer test:infra

--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
         "guzzlehttp/guzzle": "^7.10"
     },
     "scripts": {
-        "test": "vendor/bin/phpunit test --do-not-cache-result --no-progress --colors=never"
+        "test": "vendor/bin/phpunit --testsuite Unit --exclude-group integration test --do-not-cache-result --no-progress --colors=never",
+        "test:integration": "vendor/bin/phpunit --testsuite Integration --group integration --do-not-cache-result --no-progress --colors=never"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
     },
     "scripts": {
         "test": "vendor/bin/phpunit --testsuite Unit --exclude-group integration test --do-not-cache-result --no-progress --colors=never",
-        "test:integration": "vendor/bin/phpunit --testsuite Integration --group integration --do-not-cache-result --no-progress --colors=never"
+        "test:integration": "vendor/bin/phpunit --testsuite Integration --group integration --do-not-cache-result --no-progress --colors=never",
+        "test:infra": "vendor/bin/phpunit --group infra --exclude-group integration --do-not-cache-result --no-progress --colors=never"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,8 +11,12 @@
          displayDetailsOnPhpunitDeprecations="true"
 >
     <testsuites>
-        <testsuite name="Test Suite">
+        <testsuite name="Unit">
             <directory suffix="Test.php">./test</directory>
+            <exclude>./test/Integration</exclude>
+        </testsuite>
+        <testsuite name="Integration">
+            <directory suffix="Test.php">./test/Integration</directory>
         </testsuite>
     </testsuites>
     <source>

--- a/test/Database/DatabasePdoConnectorTest.php
+++ b/test/Database/DatabasePdoConnectorTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Database;
+
+use Test\TestCase;
+use Webstract\Database\DatabasePdoConnector;
+use Webstract\Env\Visitor\DatabaseEnvironmentVarVisitor;
+
+final class DatabasePdoConnectorTest extends TestCase
+{
+    private string $dsn;
+
+    protected function setUp(): void
+    {
+        $this->dsn = 'sqlite:' . sys_get_temp_dir() . '/webstract-db-' . uniqid('', true) . '.sqlite';
+        $this->resetConnectorConnection();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetConnectorConnection();
+        @unlink(str_replace('sqlite:', '', $this->dsn));
+    }
+
+    public function testItExecutesStatementsAndPersistsDataWithSqlite(): void
+    {
+        $connector = new DatabasePdoConnector($this->createDbEnv($this->dsn));
+
+        $connector->exec('CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)');
+
+        $statement = $connector->prepare('INSERT INTO users(name) VALUES (:name)');
+        self::assertNotFalse($statement);
+        $statement->execute(['name' => 'Alice']);
+
+        self::assertSame('1', $connector->lastInsertId());
+
+        $select = $connector->prepare('SELECT name FROM users WHERE id = :id');
+        self::assertNotFalse($select);
+        $select->execute(['id' => 1]);
+
+        self::assertSame('Alice', $select->fetch()->name);
+    }
+
+    public function testItHandlesTransactionsAgainstRealConnection(): void
+    {
+        $connector = new DatabasePdoConnector($this->createDbEnv($this->dsn));
+        $connector->exec('CREATE TABLE events (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)');
+
+        self::assertTrue($connector->beginTransaction());
+        self::assertTrue($connector->inTransaction());
+
+        $insert = $connector->prepare('INSERT INTO events(name) VALUES (:name)');
+        self::assertNotFalse($insert);
+        $insert->execute(['name' => 'rolled back']);
+
+        self::assertTrue($connector->rollBack());
+        self::assertFalse($connector->inTransaction());
+
+        $count = $connector->prepare('SELECT COUNT(*) as total FROM events');
+        self::assertNotFalse($count);
+        $count->execute();
+        self::assertSame(0, (int) $count->fetch()->total);
+    }
+
+    private function createDbEnv(string $dsn): DatabaseEnvironmentVarVisitor
+    {
+        return new class($dsn) implements DatabaseEnvironmentVarVisitor {
+            public function __construct(private readonly string $dsn) {}
+            public function getDatabaseDsn(): string { return $this->dsn; }
+            public function getDatabaseHost(): string { return ''; }
+            public function getDatabaseName(): string { return ''; }
+            public function getDatabaseUser(): string { return ''; }
+            public function getDatabaseType(): string { return ''; }
+            public function getDatabasePort(): string { return ''; }
+            public function getDatabasePassword(): string { return ''; }
+        };
+    }
+
+    private function resetConnectorConnection(): void
+    {
+        $reflection = new \ReflectionClass(DatabasePdoConnector::class);
+        $property = $reflection->getProperty('connection');
+        $property->setAccessible(true);
+        $property->setValue(null, null);
+    }
+}

--- a/test/Database/DatabasePdoConnectorTest.php
+++ b/test/Database/DatabasePdoConnectorTest.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Test\Database;
 
+use PHPUnit\Framework\Attributes\Group;
 use Test\TestCase;
 use Webstract\Database\DatabasePdoConnector;
 use Webstract\Env\Visitor\DatabaseEnvironmentVarVisitor;
 
+#[Group('infra')]
 final class DatabasePdoConnectorTest extends TestCase
 {
     private string $dsn;

--- a/test/Integration/Storage/S3FileHandlerIntegrationTest.php
+++ b/test/Integration/Storage/S3FileHandlerIntegrationTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Integration\Storage;
+
+use PHPUnit\Framework\Attributes\Group;
+use Test\TestCase;
+
+#[Group('integration')]
+final class S3FileHandlerIntegrationTest extends TestCase
+{
+    public function testS3IntegrationSuiteMustBeEnabledExplicitly(): void
+    {
+        $this->markTestSkipped('Optional integration suite for S3/network tests. Run only with --group integration and required infra.');
+    }
+}

--- a/test/Session/NativeSessionTest.php
+++ b/test/Session/NativeSessionTest.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Test\Session;
 
 use stdClass;
+use PHPUnit\Framework\Attributes\Group;
 use Test\TestCase;
 use Webstract\Session\Exception\SessionValueNotFoundException;
 use Webstract\Session\NativeSession;
 use Webstract\Session\SessionKeyInterface;
 
+#[Group('infra')]
 final class NativeSessionTest extends TestCase
 {
     private NativeSession $session;

--- a/test/Session/NativeSessionTest.php
+++ b/test/Session/NativeSessionTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Session;
+
+use stdClass;
+use Test\TestCase;
+use Webstract\Session\Exception\SessionValueNotFoundException;
+use Webstract\Session\NativeSession;
+use Webstract\Session\SessionKeyInterface;
+
+final class NativeSessionTest extends TestCase
+{
+    private NativeSession $session;
+
+    protected function setUp(): void
+    {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_unset();
+            session_destroy();
+        }
+
+        $_SESSION = [];
+        $this->session = new NativeSession();
+        $this->session->initSession();
+    }
+
+    protected function tearDown(): void
+    {
+        $_SESSION = [];
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_unset();
+            session_destroy();
+        }
+    }
+
+    public function testItStoresAndReadsScalarAndObjectValues(): void
+    {
+        $scalarKey = $this->key('token');
+        $objectKey = $this->key('user');
+        $object = new stdClass();
+        $object->name = 'Jane';
+
+        $this->session->set($scalarKey, 'abc123');
+        $this->session->set($objectKey, $object);
+
+        self::assertTrue($this->session->has($scalarKey));
+        self::assertSame('abc123', $this->session->get($scalarKey));
+        self::assertInstanceOf(stdClass::class, $this->session->get($objectKey));
+        self::assertSame('Jane', $this->session->get($objectKey)->name);
+    }
+
+    public function testItConsumesAndDeletesValues(): void
+    {
+        $key = $this->key('flash');
+        $this->session->set($key, 'saved');
+
+        self::assertSame('saved', $this->session->consume($key));
+        self::assertFalse($this->session->has($key));
+        self::assertSame('default', $this->session->consumeOrDefault($key, 'default'));
+    }
+
+    public function testItThrowsWhenValueIsMissing(): void
+    {
+        $this->expectException(SessionValueNotFoundException::class);
+        $this->session->get($this->key('missing'));
+    }
+
+    private function key(string $name): SessionKeyInterface
+    {
+        return new class($name) implements SessionKeyInterface {
+            public function __construct(private readonly string $name) {}
+            public function getName(): string { return $this->name; }
+        };
+    }
+}

--- a/test/Storage/PathTest.php
+++ b/test/Storage/PathTest.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Test\Storage;
 
+use PHPUnit\Framework\Attributes\Group;
 use Test\TestCase;
 use Webstract\Storage\Path;
 
+#[Group('infra')]
 final class PathTest extends TestCase
 {
     public function testItResolvesPreviousPathHierarchy(): void

--- a/test/Storage/PathTest.php
+++ b/test/Storage/PathTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Storage;
+
+use Test\TestCase;
+use Webstract\Storage\Path;
+
+final class PathTest extends TestCase
+{
+    public function testItResolvesPreviousPathHierarchy(): void
+    {
+        self::assertNull(Path::ROOT->getPrevious());
+        self::assertSame(Path::ROOT, Path::BACKUPS->getPrevious());
+        self::assertSame(Path::PROD, Path::PROD_IMAGES->getPrevious());
+        self::assertSame(Path::SANDBOX, Path::SANDBOX_BACKUPS->getPrevious());
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide realistic, local tests for critical infra components to avoid over-mocking and validate behavior against local dependencies. 
- Allow network/S3 tests to be run only explicitly to avoid flakiness and external infra requirements in the default suite. 
- Improve confidence in session/storage/database implementations by exercising real behavior (SQLite file, PHP native session, local enums) during unit runs.

### Description

- Added a SQLite-backed unit test for `DatabasePdoConnector` at `test/Database/DatabasePdoConnectorTest.php` that creates a temporary DB file, verifies `prepare/exec/lastInsertId` and transaction rollback, and resets the static PDO connection via reflection. 
- Added native session tests at `test/Session/NativeSessionTest.php` that exercise `NativeSession` for scalar and object storage, serialization behavior, `consume`/`consumeOrDefault`, deletion, and missing-value exception handling. 
- Added a local storage enum test at `test/Storage/PathTest.php` to validate `Path::getPrevious()` hierarchy without external services. 
- Added an integration placeholder at `test/Integration/Storage/S3FileHandlerIntegrationTest.php` tagged with the `integration` group and skipped by default, and updated `phpunit.xml` and `composer.json` to split `Unit` and `Integration` suites and provide a `test:integration` script.

### Testing

- Ran PHP syntax checks with `php -l` against all new test files, and they passed. 
- Attempted to run `composer test` but it failed because `vendor/bin/phpunit` was not available in the current environment. 
- Confirmed tests are committed and configured so that running `composer test` with dev deps installed will execute the unit suite while integration tests remain opt-in via `composer run test:integration`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2a9927e00832486deb26631a4dec3)